### PR TITLE
Feature: Edit Start Time of beacon

### DIFF
--- a/graphql/resolvers.js
+++ b/graphql/resolvers.js
@@ -98,7 +98,7 @@ const resolvers = {
 
         createBeacon: async (_, { beacon }, { user }) => {
             console.log(beacon);
-
+            if (beacon.startsAt>beacon.expiresAt) return Error("Beacon can not expire before it has started.");
             const beaconDoc = new Beacon({
                 leader: user.id,
                 shortcode: nanoid(),
@@ -113,14 +113,15 @@ const resolvers = {
             return newBeacon;
         },
 
-        changeBeaconDuration: async (_, { newExpiresAt, beaconID }, { user }) => {
+        changeBeaconDuration: async (_, { newStartsAt, newExpiresAt, beaconID }, { user }) => {
             const beacon = await Beacon.findById(beaconID).populate("leader");
 
             if (!beacon) return new UserInputError("No beacon exists with that id.");
             if (beacon.leader.id != user.id)
                 return new Error("Only the leader is allowed to change the beacon duration.");
-            if (beacon.startsAt.getTime() > newExpiresAt) return Error("Beacon can not expire before it has started.");
+            if (newStartsAt > newExpiresAt) return Error("Beacon can not expire before it has started.");
 
+            beacon.startsAt = newStartsAt;
             beacon.expiresAt = newExpiresAt;
             await beacon.save();
 

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -103,7 +103,7 @@ const typeDefs = gql`
         updateBeaconLocation(id: ID!, location: LocationInput!): Beacon!
         updateUserLocation(id: ID!, location: LocationInput!): User!
         changeLeader(beaconID: ID!, newLeaderID: ID!): Beacon!
-        changeBeaconDuration(newExpiresAt: Float!, beaconID: ID!): Beacon!
+        changeBeaconDuration(newStartsAt: Float!, newExpiresAt: Float!, beaconID: ID!): Beacon!
     }
 
     type Subscription {


### PR DESCRIPTION
Fixes #98 

- Added `startsAt` argument in `changeBeaconDuration` mutation to allow users to even edit the start time of a beacon as and when required.
- Also, added a conditional statement to pass error message when given starting time is after expiring time while using `createBeacon` mutation.