### PR TITLE
Feat-Mutation for forgot password option #95

### DIFF
--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -104,6 +104,17 @@ const typeDefs = gql`
         hello: String
     }
 
+    type requestPasswordResetResponse {
+        message: String!
+        success: Boolean!
+        encryptOtp: String!
+      }
+
+      type PasswordResetResponse {
+        message: String!
+        success: Boolean!
+      }
+
     type Mutation {
         """
         if start time not supplied, default is Date.now
@@ -122,6 +133,9 @@ const typeDefs = gql`
         changeBeaconDuration(newExpiresAt: Float!, beaconID: ID!): Beacon!
         createGroup(group: GroupInput): Group!
         joinGroup(shortcode: String!): Group!
+        requestPasswordReset(email: String!): requestPasswordResetResponse!
+        verifyPasswordResetOtp(userOtp: String!): PasswordResetResponse!
+        resetPassword(credentials: AuthPayload): PasswordResetResponse!
     }
 
     type Subscription {

--- a/index.mjs
+++ b/index.mjs
@@ -21,8 +21,9 @@ const server = new ApolloServer({
         if (connection) {
             return { user: connection.context.user, pubsub };
         }
+        const otp = req?.headers?.otp || (connection?.context?.headers?.otp ? connection.context.headers.otp : null);
         const user = req?.user ? await User.findById(req.user.sub).populate("beacons") : null;
-        return { user, pubsub };
+        return { user, pubsub, otp };
     },
     stopGracePeriodMillis: Infinity,
     stopOnTerminationSignals: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
         "jsonwebtoken": "^8.5.1",
         "mongoose": "^6.2.6",
         "nanoid": "^3.3.1",
+        "nodemailer": "^6.9.7",
+        "otp-generator": "^4.0.1",
         "pm2": "^5.2.0"
       },
       "devDependencies": {
@@ -8579,6 +8581,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/nodemailer": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.7.tgz",
+      "integrity": "sha512-rUtR77ksqex/eZRLmQ21LKVH5nAAsVicAtAYudK7JgwenEDZ0UIQ1adUGqErz7sMkWYxWTTU1aeP2Jga6WQyJw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -8838,6 +8848,14 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/otp-generator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/otp-generator/-/otp-generator-4.0.1.tgz",
+      "integrity": "sha512-2TJ52vUftA0+J3eque4wwVtpaL4/NdIXDL0gFWFJFVUAZwAN7+9tltMhL7GCNYaHJtuONoier8Hayyj4HLbSag==",
+      "engines": {
+        "node": ">=14.10.0"
       }
     },
     "node_modules/p-cancelable": {
@@ -18759,6 +18777,11 @@
         "sorted-array-functions": "^1.3.0"
       }
     },
+    "nodemailer": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.7.tgz",
+      "integrity": "sha512-rUtR77ksqex/eZRLmQ21LKVH5nAAsVicAtAYudK7JgwenEDZ0UIQ1adUGqErz7sMkWYxWTTU1aeP2Jga6WQyJw=="
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -18945,6 +18968,11 @@
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "dev": true,
       "peer": true
+    },
+    "otp-generator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/otp-generator/-/otp-generator-4.0.1.tgz",
+      "integrity": "sha512-2TJ52vUftA0+J3eque4wwVtpaL4/NdIXDL0gFWFJFVUAZwAN7+9tltMhL7GCNYaHJtuONoier8Hayyj4HLbSag=="
     },
     "p-cancelable": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^6.2.6",
     "nanoid": "^3.3.1",
+    "nodemailer": "^6.9.7",
+    "otp-generator": "^4.0.1",
     "pm2": "^5.2.0"
   },
   "devDependencies": {

--- a/permissions/index.js
+++ b/permissions/index.js
@@ -8,6 +8,9 @@ const permissions = shield({
     },
     Mutation: {
         "*": isAuthenticated,
+        requestPasswordReset: not(isAuthenticated),
+        verifyPasswordResetOtp: not(isAuthenticated),
+        resetPassword: not(isAuthenticated),
         register: not(isAuthenticated),
         login: not(isAuthenticated),
     },

--- a/utils/generate_otp.js
+++ b/utils/generate_otp.js
@@ -1,0 +1,7 @@
+const otpGenerator = require('otp-generator')
+
+const generateOtp = () => {
+    return otpGenerator.generate(6, { upperCaseAlphabets: false, lowerCaseAlphabets: false, specialChars: false });
+}
+
+module.exports = {generateOtp};

--- a/utils/send_email.js
+++ b/utils/send_email.js
@@ -1,0 +1,36 @@
+const nodemailer = require("nodemailer");
+const { generateOtp } = require("./generate_otp");
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: process.env.SMTP_PORT,
+  secure: true,
+  auth: {
+    user: process.env.SMTP_MAIL,
+    pass: process.env.SMTP_PASSWORD,
+  },
+});
+
+const sendEmail = (email) => {
+    
+    const otp = generateOtp();
+    var mailOptions = {
+        from: process.env.SMTP_MAIL,
+        to: email,
+        subject: "OTP from CCExtractor Beacon",
+        html: `<p>Dear User, Your OTP for reseting password from CCExtractor BEACON is :</p> <b>${otp}</b>`
+    }
+
+    transporter.sendMail(mailOptions, (error, info) => {
+        if(error){
+            console.log("Error -", error);
+            return false;
+        }else{
+            console.log("Email send Successfully");
+            return true;
+        }
+    })
+    return otp;
+}
+
+module.exports = {sendEmail};


### PR DESCRIPTION
I did the following changes to implement the forgot password feature -:
 **1. Schema** 
a. requestPasswordReset - take email and give message, success, and encrypted otp in response.
b. verifyPasswordResetOtp - take otp from user and give message and success in response.
c. resetPassword - take email and new password and give  message, success in response.
**2.Resolver**
a. requestPasswordReset - send otp to email and give encrypted otp
b. verifyPasswordResetOtp - compare given otp and encrypted otp and verify user
c. resetPassword - update the user password

To use this feature, some things to do in frontend -:
**1.** Store the email and encrypted otp in local storage for limited time (e.g - 2min) 
**2.** Extract otp from local storage and set it in header using apollo client here's how you can do this 
In index.js file add this code 
```
const client = new ApolloClient({
  uri: '<enter url here>',
  cache: new InMemoryCache(),
  headers: {
    otp: localStorage.getItem("otp") || ""
  }
});
```
**3.** Extract email from local storage and take new password from user and give it to resetPassword 



I use nodemailer and otp-generator npm packages.
User dont need to be Authorized in order to forgot his password.
